### PR TITLE
feat: add organization-level rotating kiosk display URL

### DIFF
--- a/backend/frontend/src/LandingPage.tsx
+++ b/backend/frontend/src/LandingPage.tsx
@@ -134,6 +134,11 @@ type LoginResponse = {
 
 type DisplayBoardLaunchResponse = {
   displayOnly: boolean
+  organization?: {
+    id: number
+    team_name: string | null
+  } | null
+  organizationRotationSeconds?: number | null
   pool: LandingPool | null
   games: LandingGame[]
   selectedGameId: number | null
@@ -888,6 +893,7 @@ export function LandingPage() {
   const [displayAdItems, setDisplayAdItems] = useState<DisplayAdItem[]>([])
   const [displayAdSettings, setDisplayAdSettings] = useState<DisplayAdSettings>(DEFAULT_DISPLAY_AD_SETTINGS)
   const [postgameRotationSeconds, setPostgameRotationSeconds] = useState<number | null>(null)
+  const [organizationRotationSeconds, setOrganizationRotationSeconds] = useState<number | null>(null)
   const [authMode, setAuthMode] = useState<'login' | 'reset' | 'request-access'>('login')
   const [loginForm, setLoginForm] = useState({ email: '', password: '' })
   const [resetForm, setResetForm] = useState({ email: '', token: '', password: '', confirmPassword: '' })
@@ -1106,6 +1112,11 @@ export function LandingPage() {
           ? Math.max(5, Math.floor(launch.postgameRotationSeconds))
           : null
       )
+      setOrganizationRotationSeconds(
+        typeof launch.organizationRotationSeconds === 'number' && Number.isFinite(launch.organizationRotationSeconds)
+          ? Math.max(5, Math.floor(launch.organizationRotationSeconds))
+          : null
+      )
       setActiveDisplayAdIndex((current) => (nextDisplayAdInventoryCount > 0 ? current % nextDisplayAdInventoryCount : 0))
       if (!nextDisplayAdSettings.adsEnabled || nextDisplayAdSettings.hideAdsForOrganization || nextDisplayAdInventoryCount === 0) {
         setDisplayAdVisible(false)
@@ -1128,6 +1139,7 @@ export function LandingPage() {
         setDisplayAdSettings(DEFAULT_DISPLAY_AD_SETTINGS)
         setDisplayAdVisible(false)
         setPostgameRotationSeconds(null)
+        setOrganizationRotationSeconds(null)
       }
     } finally {
       if (quiet) {
@@ -1200,9 +1212,17 @@ export function LandingPage() {
     let intervalId: number | null = null
 
     if (displayOnlyMode && displayToken) {
-      const effectiveDisplayRefreshSeconds = postgameRotationSeconds != null
-        ? Math.max(5, Math.min(displayRefreshSeconds, postgameRotationSeconds))
-        : displayRefreshSeconds
+      const cadenceCandidates = [displayRefreshSeconds]
+
+      if (postgameRotationSeconds != null) {
+        cadenceCandidates.push(postgameRotationSeconds)
+      }
+
+      if (organizationRotationSeconds != null) {
+        cadenceCandidates.push(organizationRotationSeconds)
+      }
+
+      const effectiveDisplayRefreshSeconds = Math.max(5, Math.min(...cadenceCandidates))
 
       intervalId = window.setInterval(() => {
         void loadDisplayBoard(displayToken, { quiet: true })
@@ -1274,7 +1294,7 @@ export function LandingPage() {
       eventSource.removeEventListener('game-updated', handleGameUpdated as EventListener)
       eventSource.close()
     }
-  }, [activePage, board?.gameId, displayOnlyMode, displayRefreshSeconds, displayToken, games, postgameRotationSeconds, selectedGameId, selectedPoolId, token])
+  }, [activePage, board?.gameId, displayOnlyMode, displayRefreshSeconds, displayToken, games, organizationRotationSeconds, postgameRotationSeconds, selectedGameId, selectedPoolId, token])
 
   useEffect(() => {
     if (typeof document === 'undefined') {

--- a/backend/frontend/src/LandingTeamMaintenance.tsx
+++ b/backend/frontend/src/LandingTeamMaintenance.tsx
@@ -14,6 +14,8 @@ type TeamRecord = {
   secondary_contact_id: number | null
   has_members_flg?: boolean | null
   sport_team_id?: number | null
+  display_token?: string | null
+  display_rotation_seconds?: number | null
 }
 
 type DirectoryUser = {
@@ -103,7 +105,8 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
     logoFile: '',
     primaryContactId: '',
     secondaryContactId: '',
-    hasMembers: true
+    hasMembers: true,
+    displayRotationSeconds: '30'
   })
 
   const canManageTeams = Boolean(token)
@@ -133,7 +136,8 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
       logoFile: storedLogo,
       primaryContactId: team?.primary_contact_id != null ? String(team.primary_contact_id) : '',
       secondaryContactId: team?.secondary_contact_id != null ? String(team.secondary_contact_id) : '',
-      hasMembers: team?.has_members_flg ?? true
+      hasMembers: team?.has_members_flg ?? true,
+      displayRotationSeconds: String(team?.display_rotation_seconds ?? 30)
     })
   }
 
@@ -230,6 +234,20 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
     () => teams.find((team) => team.id === selectedTeamId) ?? null,
     [selectedTeamId, teams]
   )
+
+  const displayUrl = useMemo(() => {
+    if (!selectedTeam?.display_token) {
+      return ''
+    }
+
+    if (typeof window === 'undefined') {
+      return `?display=${selectedTeam.display_token}`
+    }
+
+    const url = new URL(window.location.pathname, window.location.origin)
+    url.searchParams.set('display', selectedTeam.display_token)
+    return url.toString()
+  }, [selectedTeam])
 
   const onSelectTeam = (teamId: number): void => {
     const team = teams.find((entry) => entry.id === teamId) ?? null
@@ -329,9 +347,15 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
 
   const onSaveTeam = async (): Promise<void> => {
     const trimmedName = teamForm.teamName.trim()
+    const parsedDisplayRotationSeconds = Number.parseInt(teamForm.displayRotationSeconds, 10)
 
     if (!trimmedName) {
       setError('Organization name is required.')
+      return
+    }
+
+    if (!Number.isFinite(parsedDisplayRotationSeconds) || parsedDisplayRotationSeconds < 5 || parsedDisplayRotationSeconds > 3600) {
+      setError('Organization kiosk rotation seconds must be between 5 and 3600.')
       return
     }
 
@@ -352,7 +376,8 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
         logoFile: teamForm.logoFile ? normalizeLogoFile(teamForm.logoFile.trim()) : undefined,
         primaryContactId: teamForm.primaryContactId ? Number(teamForm.primaryContactId) : undefined,
         secondaryContactId: teamForm.secondaryContactId ? Number(teamForm.secondaryContactId) : undefined,
-        hasMembers: teamForm.hasMembers
+        hasMembers: teamForm.hasMembers,
+        displayRotationSeconds: parsedDisplayRotationSeconds
       }
 
       if (isCreatingNew) {
@@ -529,6 +554,20 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
             <div className="landing-selected-summary-header">
               <div>
                 <strong>{selectedTeam ? formatTeamName(selectedTeam) : 'New organization'}</strong>
+                {selectedTeam ? (
+                  displayUrl ? (
+                    <div>
+                      <p className="small landing-readonly-note">Organization display link opens the Squares board in read-only mode and rotates through this organization&apos;s pools using the interval below.</p>
+                      <label className="field-block">
+                        <span>Organization display URL</span>
+                        <input value={displayUrl} readOnly onFocus={(event) => event.currentTarget.select()} />
+                      </label>
+                      <a href={displayUrl} target="_blank" rel="noreferrer">Open organization display view</a>
+                    </div>
+                  ) : (
+                    <p className="small">Save the organization to generate its rotating display URL.</p>
+                  )
+                ) : null}
               </div>
             </div>
           </div>
@@ -578,6 +617,19 @@ export function LandingTeamMaintenance({ pools, token, authHeaders, apiBase, onR
                 disabled={saving}
               />
               <span>Track members in this organization</span>
+            </label>
+
+            <label className="field-block">
+              <span>Pool rotation seconds</span>
+              <input
+                type="number"
+                min={5}
+                max={3600}
+                value={teamForm.displayRotationSeconds}
+                onChange={(event) => setTeamForm((current) => ({ ...current, displayRotationSeconds: event.target.value }))}
+                disabled={saving}
+              />
+              <small className="small">How long the organization kiosk should show each pool before cycling to the next one.</small>
             </label>
 
             <label className="field-block landing-field-span">

--- a/backend/migrations/033_add_organization_display_link.sql
+++ b/backend/migrations/033_add_organization_display_link.sql
@@ -1,0 +1,18 @@
+ALTER TABLE football_pool.organization
+  ADD COLUMN IF NOT EXISTS display_token VARCHAR(32);
+
+ALTER TABLE football_pool.organization
+  ADD COLUMN IF NOT EXISTS display_rotation_seconds INTEGER NOT NULL DEFAULT 30;
+
+UPDATE football_pool.organization
+SET display_rotation_seconds = 30
+WHERE display_rotation_seconds IS NULL
+   OR display_rotation_seconds < 5;
+
+UPDATE football_pool.organization
+SET display_token = SUBSTRING(md5(id::text || clock_timestamp()::text || random()::text) FROM 1 FOR 16)
+WHERE display_token IS NULL
+   OR BTRIM(display_token) = '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_organization_display_token
+  ON football_pool.organization (display_token);

--- a/backend/src/api.test.ts
+++ b/backend/src/api.test.ts
@@ -1540,6 +1540,84 @@ describe('Football Pool API', () => {
       }
     })
 
+    it('should rotate an organization display link across the organization\'s pools on its configured cadence', async () => {
+      vi.useFakeTimers()
+
+      try {
+        const teamResponse = await request(app)
+          .post('/api/setup/teams')
+          .set(organizerHeaders)
+          .send({
+            teamName: `Organization Display ${Date.now()}`,
+            displayRotationSeconds: 12
+          })
+
+        expect(teamResponse.status).toBe(201)
+        const organizationId = Number(teamResponse.body.id)
+
+        const firstPoolResponse = await request(app)
+          .post('/api/setup/pools')
+          .set(organizerHeaders)
+          .send({
+            poolName: `Org Display Pool A ${Date.now()}`,
+            teamId: organizationId,
+            season: 2026,
+            primaryTeam: 'Packers',
+            squareCost: 25,
+            q1Payout: 250,
+            q2Payout: 250,
+            q3Payout: 250,
+            q4Payout: 500
+          })
+
+        const secondPoolResponse = await request(app)
+          .post('/api/setup/pools')
+          .set(organizerHeaders)
+          .send({
+            poolName: `Org Display Pool B ${Date.now()}`,
+            teamId: organizationId,
+            season: 2026,
+            primaryTeam: 'Packers',
+            squareCost: 25,
+            q1Payout: 250,
+            q2Payout: 250,
+            q3Payout: 250,
+            q4Payout: 500
+          })
+
+        expect(firstPoolResponse.status).toBe(201)
+        expect(secondPoolResponse.status).toBe(201)
+
+        const firstPoolId = Number(firstPoolResponse.body.id)
+        const secondPoolId = Number(secondPoolResponse.body.id)
+        const organizationTokenResult = await db.query<{ display_token: string }>(
+          `SELECT display_token
+           FROM football_pool.organization
+           WHERE id = $1`,
+          [organizationId]
+        )
+        const organizationDisplayToken = String(organizationTokenResult.rows[0]?.display_token ?? '')
+
+        vi.setSystemTime(new Date('2026-09-11T12:00:00.000Z'))
+        const firstDisplayResponse = await request(app).get(`/api/landing/display/${organizationDisplayToken}`)
+
+        vi.setSystemTime(new Date('2026-09-11T12:00:13.000Z'))
+        const secondDisplayResponse = await request(app).get(`/api/landing/display/${organizationDisplayToken}`)
+
+        expect(firstDisplayResponse.status).toBe(200)
+        expect(secondDisplayResponse.status).toBe(200)
+        expect(firstDisplayResponse.body.organization?.id).toBe(organizationId)
+        expect(firstDisplayResponse.body.organizationRotationSeconds).toBe(12)
+        expect([firstPoolId, secondPoolId]).toContain(firstDisplayResponse.body.pool?.id)
+        expect([firstPoolId, secondPoolId]).toContain(secondDisplayResponse.body.pool?.id)
+        expect(new Set([firstDisplayResponse.body.pool?.id, secondDisplayResponse.body.pool?.id])).toEqual(
+          new Set([firstPoolId, secondPoolId])
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('should keep rotating until a scheduled MLB game with a placeholder noon kickoff actually goes live', async () => {
       vi.useFakeTimers()
 

--- a/backend/src/routes/landing.ts
+++ b/backend/src/routes/landing.ts
@@ -6,7 +6,11 @@ import { db } from '../config/db';
 import { env } from '../config/env';
 import { getPoolLeagueDefinition, getPayoutValueForSlot, type PayoutSlotKey } from '../config/poolLeagues';
 import { ensurePoolSquaresInitialized } from '../services/poolSquares';
-import { ensurePoolDisplayTokenSupport } from '../services/poolDisplay';
+import {
+  ensureOrganizationDisplayTokenSupport,
+  ensurePoolDisplayTokenSupport,
+  getOrganizationDisplayRotationSeconds
+} from '../services/poolDisplay';
 import { getPoolSimulationStatus } from '../services/poolSimulation';
 import { ensureNotificationSupport } from '../services/notifications';
 import { loadPoolPayoutConfig, resolvePoolPayoutsForRound } from '../services/poolPayouts';
@@ -428,6 +432,72 @@ const loadPoolByDisplayToken = async (client: PoolClient, displayToken: string) 
   );
 
   return result.rows[0] ?? null;
+};
+
+const loadOrganizationByDisplayToken = async (client: PoolClient, displayToken: string) => {
+  await ensureOrganizationDisplayTokenSupport(client);
+
+  const result = await client.query(
+    `SELECT id,
+            team_name,
+            primary_color,
+            secondary_color,
+            logo_file,
+            COALESCE(display_token, '') AS display_token,
+            COALESCE(display_rotation_seconds, 30) AS display_rotation_seconds
+     FROM football_pool.organization
+     WHERE display_token = $1
+     LIMIT 1`,
+    [displayToken]
+  );
+
+  return result.rows[0] ?? null;
+};
+
+const loadOrganizationPoolsForDisplay = async (client: PoolClient, organizationId: number) => {
+  await ensurePoolDisplayTokenSupport(client);
+
+  const result = await client.query(
+    `SELECT p.id,
+            p.pool_name,
+            p.season,
+            p.team_id,
+            COALESCE(p.pool_type, 'season') AS pool_type,
+            p.primary_team,
+            p.primary_sport_team_id,
+            p.sport_code,
+            p.league_code,
+            COALESCE(p.winner_loser_flg, FALSE) AS winner_loser_flg,
+            p.square_cost,
+            COALESCE(p.default_flg, FALSE) AS default_flg,
+            COALESCE(p.sign_in_req_flg, FALSE) AS sign_in_req_flg,
+            COALESCE(p.display_token, '') AS display_token,
+            t.team_name,
+            COALESCE(NULLIF(t.primary_color, ''), st.primary_color) AS primary_color,
+            t.secondary_color,
+            COALESCE(NULLIF(t.logo_file, ''), st.logo_url) AS logo_file,
+            COALESCE(t.has_members_flg, TRUE) AS has_members_flg
+     FROM football_pool.pool p
+     LEFT JOIN football_pool.organization t ON t.id = p.team_id
+     LEFT JOIN football_pool.sport_team st ON st.id = COALESCE(p.primary_sport_team_id, t.sport_team_id)
+     WHERE p.team_id = $1
+     ORDER BY COALESCE(p.default_flg, FALSE) DESC,
+              p.pool_name NULLS LAST,
+              p.id`,
+    [organizationId]
+  );
+
+  return result.rows;
+};
+
+const pickDisplayPoolId = (pools: Array<{ id: number }>, rotationSeconds: number): number | null => {
+  if (pools.length === 0) {
+    return null;
+  }
+
+  const rotationMs = Math.max(5, rotationSeconds) * 1000;
+  const poolIndex = Math.floor(Date.now() / rotationMs) % pools.length;
+  return Number(pools[Math.max(0, poolIndex)]?.id ?? pools[0].id);
 };
 
 const pickDisplayGameId = (
@@ -1449,17 +1519,35 @@ landingRouter.get('/display/:displayToken', async (req, res) => {
 
     const client = await db.connect();
     try {
-      const pool = await loadPoolByDisplayToken(client, displayToken);
+      let pool = await loadPoolByDisplayToken(client, displayToken);
+      const organization = pool ? null : await loadOrganizationByDisplayToken(client, displayToken);
+      let organizationRotationSeconds: number | null = null;
+
+      if (!pool && organization) {
+        const organizationPools = await loadOrganizationPoolsForDisplay(client, Number(organization.id));
+
+        if (organizationPools.length === 0) {
+          return res.status(404).json({ error: 'Organization display link has no pools to show yet' });
+        }
+
+        organizationRotationSeconds = getOrganizationDisplayRotationSeconds(organization.display_rotation_seconds);
+        const selectedPoolId = pickDisplayPoolId(
+          organizationPools as Array<{ id: number }>,
+          organizationRotationSeconds
+        );
+
+        pool = organizationPools.find((entry) => Number(entry.id) === Number(selectedPoolId)) ?? organizationPools[0];
+      }
 
       if (!pool) {
-        return res.status(404).json({ error: 'Pool display link not found' });
+        return res.status(404).json({ error: 'Display link not found' });
       }
 
       await ensureDisplayAdvertisingSupport(client);
       const games = await loadPoolGames(client, Number(pool.id));
       const simulationStatus = await getPoolSimulationStatus(client, Number(pool.id)).catch(() => null);
       const { settings: displayAdSettings, ads: displayAds } = await loadDisplayAdvertising(client, {
-        organizationId: Number(pool.team_id ?? 0) || null
+        organizationId: Number(pool.team_id ?? organization?.id ?? 0) || null
       });
       const selectedGameId = pickDisplayGameId(
         games as Array<{
@@ -1494,6 +1582,13 @@ landingRouter.get('/display/:displayToken', async (req, res) => {
 
       return res.json({
         displayOnly: true,
+        organization: organization
+          ? {
+              id: Number(organization.id),
+              team_name: organization.team_name ?? null
+            }
+          : null,
+        organizationRotationSeconds,
         pool,
         games,
         selectedGameId,

--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -27,7 +27,13 @@ import {
   getPoolSimulationStatus
 } from '../services/poolSimulation';
 import { ensurePoolSquaresInitialized } from '../services/poolSquares';
-import { ensurePoolDisplayTokenSupport, generateUniquePoolDisplayToken } from '../services/poolDisplay';
+import {
+  DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS,
+  ensureOrganizationDisplayTokenSupport,
+  ensurePoolDisplayTokenSupport,
+  generateUniqueOrganizationDisplayToken,
+  generateUniquePoolDisplayToken
+} from '../services/poolDisplay';
 import { ensureNotificationSupport } from '../services/notifications';
 import { ensurePoolGameStructureSupport } from '../services/poolGameStructureSupport';
 import { ensurePoolPayoutStructureSupport } from '../services/poolPayoutStructureSupport';
@@ -301,6 +307,7 @@ const createTeamSchema = z.object({
   primaryContactId: z.number().int().positive().optional(),
   secondaryContactId: z.number().int().positive().optional(),
   hasMembers: z.boolean().optional(),
+  displayRotationSeconds: z.number().int().min(5).max(3600).optional(),
   sportTeamId: z.number().int().positive().optional(),
   espnTeamUid: z.string().trim().min(1).max(64).optional(),
   sportTeamAbbr: z.string().trim().min(1).max(16).optional(),
@@ -1727,9 +1734,12 @@ setupRouter.post('/teams', async (req, res) => {
     }
 
     await client.query('BEGIN');
+    await ensureOrganizationDisplayTokenSupport(client);
     const id = await nextId(client, 'organization');
     const resolvedSportTeamId = await resolveSportTeamId(client, parsed.data);
     const tracksMembers = parsed.data.hasMembers ?? true;
+    const displayToken = await generateUniqueOrganizationDisplayToken(client);
+    const displayRotationSeconds = parsed.data.displayRotationSeconds ?? DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS;
 
     await client.query(
       `
@@ -1743,9 +1753,11 @@ setupRouter.post('/teams', async (req, res) => {
           secondary_contact_id,
           has_members_flg,
           sport_team_id,
+          display_token,
+          display_rotation_seconds,
           created_at
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
       `,
       [
         id,
@@ -1756,7 +1768,9 @@ setupRouter.post('/teams', async (req, res) => {
         parsed.data.primaryContactId ?? null,
         parsed.data.secondaryContactId ?? null,
         tracksMembers,
-        resolvedSportTeamId
+        resolvedSportTeamId,
+        displayToken,
+        displayRotationSeconds
       ]
     );
 
@@ -1765,7 +1779,9 @@ setupRouter.post('/teams', async (req, res) => {
       id,
       sport_team_id: resolvedSportTeamId,
       nfl_team_id: resolvedSportTeamId,
-      has_members_flg: tracksMembers
+      has_members_flg: tracksMembers,
+      display_token: displayToken,
+      display_rotation_seconds: displayRotationSeconds
     });
   } catch (error) {
     await client.query('ROLLBACK');
@@ -2774,8 +2790,12 @@ setupRouter.delete('/users/:userId', async (req, res) => {
 });
 
 setupRouter.get('/teams', async (req, res) => {
+  const client = await db.connect();
+
   try {
-    const result = await db.query(
+    await ensureOrganizationDisplayTokenSupport(client);
+
+    const result = await client.query(
       `
         SELECT
           id,
@@ -2786,7 +2806,9 @@ setupRouter.get('/teams', async (req, res) => {
           primary_contact_id,
           secondary_contact_id,
           COALESCE(has_members_flg, TRUE) AS has_members_flg,
-          sport_team_id
+          sport_team_id,
+          COALESCE(display_token, '') AS display_token,
+          COALESCE(display_rotation_seconds, ${DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS}) AS display_rotation_seconds
         FROM football_pool.organization
         WHERE ($1::boolean = TRUE OR id = ANY($2::int[]))
         ORDER BY team_name, id
@@ -2801,6 +2823,8 @@ setupRouter.get('/teams', async (req, res) => {
       error: 'Failed to load teams',
       detail: error instanceof Error ? error.message : 'Unknown error'
     });
+  } finally {
+    client.release();
   }
 });
 
@@ -2886,14 +2910,17 @@ setupRouter.patch('/teams/:teamId', async (req, res) => {
     return;
   }
 
+  const client = await db.connect();
+
   try {
     if (!ensureOrganizationScope(req, res, parsedParams.data.teamId)) {
       return;
     }
 
-    const resolvedSportTeamId = await resolveSportTeamId(db, parsedBody.data);
+    await ensureOrganizationDisplayTokenSupport(client);
+    const resolvedSportTeamId = await resolveSportTeamId(client, parsedBody.data);
 
-    const result = await db.query(
+    const result = await client.query(
       `
         UPDATE football_pool.organization
         SET
@@ -2904,7 +2931,8 @@ setupRouter.patch('/teams/:teamId', async (req, res) => {
           primary_contact_id = $6,
           secondary_contact_id = $7,
           has_members_flg = COALESCE($8, has_members_flg),
-          sport_team_id = COALESCE($9, sport_team_id)
+          sport_team_id = COALESCE($9, sport_team_id),
+          display_rotation_seconds = COALESCE($10, display_rotation_seconds)
         WHERE id = $1
         RETURNING id
       `,
@@ -2917,7 +2945,8 @@ setupRouter.patch('/teams/:teamId', async (req, res) => {
         parsedBody.data.primaryContactId ?? null,
         parsedBody.data.secondaryContactId ?? null,
         parsedBody.data.hasMembers ?? null,
-        resolvedSportTeamId
+        resolvedSportTeamId,
+        parsedBody.data.displayRotationSeconds ?? null
       ]
     );
 
@@ -2932,6 +2961,8 @@ setupRouter.patch('/teams/:teamId', async (req, res) => {
       error: 'Failed to update team',
       detail: error instanceof Error ? error.message : 'Unknown error'
     });
+  } finally {
+    client.release();
   }
 });
 

--- a/backend/src/services/poolDisplay.ts
+++ b/backend/src/services/poolDisplay.ts
@@ -2,6 +2,9 @@ import { randomBytes } from 'crypto';
 import type { PoolClient } from 'pg';
 
 let ensurePoolDisplayTokenSupportPromise: Promise<void> | null = null;
+let ensureOrganizationDisplayTokenSupportPromise: Promise<void> | null = null;
+
+export const DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS = 30;
 
 export const ensurePoolDisplayTokenSupport = async (client: PoolClient): Promise<void> => {
   if (!ensurePoolDisplayTokenSupportPromise) {
@@ -33,6 +36,49 @@ export const ensurePoolDisplayTokenSupport = async (client: PoolClient): Promise
   }
 };
 
+export const ensureOrganizationDisplayTokenSupport = async (client: PoolClient): Promise<void> => {
+  if (!ensureOrganizationDisplayTokenSupportPromise) {
+    ensureOrganizationDisplayTokenSupportPromise = (async () => {
+      await client.query(`
+        ALTER TABLE football_pool.organization
+        ADD COLUMN IF NOT EXISTS display_token VARCHAR(32)
+      `);
+
+      await client.query(`
+        ALTER TABLE football_pool.organization
+        ADD COLUMN IF NOT EXISTS display_rotation_seconds INTEGER NOT NULL DEFAULT ${DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS}
+      `);
+
+      await client.query(
+        `UPDATE football_pool.organization
+         SET display_rotation_seconds = $1
+         WHERE display_rotation_seconds IS NULL
+            OR display_rotation_seconds < 5`,
+        [DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS]
+      );
+
+      await client.query(`
+        UPDATE football_pool.organization
+        SET display_token = SUBSTRING(md5(id::text || clock_timestamp()::text || random()::text) FROM 1 FOR 16)
+        WHERE display_token IS NULL
+           OR BTRIM(display_token) = ''
+      `);
+
+      await client.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_organization_display_token
+          ON football_pool.organization (display_token)
+      `);
+    })();
+  }
+
+  try {
+    await ensureOrganizationDisplayTokenSupportPromise;
+  } catch (error) {
+    ensureOrganizationDisplayTokenSupportPromise = null;
+    throw error;
+  }
+};
+
 export const generateUniquePoolDisplayToken = async (client: PoolClient): Promise<string> => {
   await ensurePoolDisplayTokenSupport(client);
 
@@ -46,4 +92,29 @@ export const generateUniquePoolDisplayToken = async (client: PoolClient): Promis
   }
 
   throw new Error('Failed to generate a unique pool display token.');
+};
+
+export const generateUniqueOrganizationDisplayToken = async (client: PoolClient): Promise<string> => {
+  await ensureOrganizationDisplayTokenSupport(client);
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const token = randomBytes(9).toString('base64url');
+    const existing = await client.query(`SELECT 1 FROM football_pool.organization WHERE display_token = $1 LIMIT 1`, [token]);
+
+    if ((existing.rowCount ?? 0) === 0) {
+      return token;
+    }
+  }
+
+  throw new Error('Failed to generate a unique organization display token.');
+};
+
+export const getOrganizationDisplayRotationSeconds = (value: unknown): number => {
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_ORGANIZATION_DISPLAY_ROTATION_SECONDS;
+  }
+
+  return Math.max(5, Math.min(3600, Math.floor(numeric)));
 };


### PR DESCRIPTION
Adds organization-level kiosk display links that rotate across all pools for an organization on a configurable per-org cadence.

## Changes
- poolDisplay.ts: org display token generation and helpers
- setup.ts: org CRUD now exposes/stores display_token and display_rotation_seconds
- landing.ts: /api/landing/display/:token resolves pool or org token; org rotates across pools
- LandingPage.tsx: refresh cadence respects org rotation seconds
- LandingTeamMaintenance.tsx: org maintenance UI shows display URL and configurable rotation setting
-  33_add_organization_display_link.sql: migration adds display_token and display_rotation_seconds to organization table